### PR TITLE
Improve performance of feature_store.get

### DIFF
--- a/feature_store.js
+++ b/feature_store.js
@@ -18,7 +18,7 @@ function InMemoryFeatureStore() {
 
   function callbackResult(cb, result) {
     cb = cb || noop;
-    setTimeout(function() { cb(result); }, 0);  // ensure this is dispatched asynchronously
+    process.nextTick(cb.bind(null, result)); // ensure this is dispatched asynchronously
   }
 
   store.get = function(kind, key, cb) {


### PR DESCRIPTION
We recently upgraded `ldclient-node` from `3.0.15` to `5.7.3` and we noticed a significant degradation in the performance of our application. We tracked this down to the changes made to the `feature-store` to support asynchronous APIs and the use of `setTimeout` specifically.

`process.nextTick` appears to perform much faster than `setTimeout` and marginally faster than `setImmediate` in environments we've tested in.
(Docker running on 64bit Amazon Linux/2.12.10 with NodeJS 8.11.3)

This nodejs event loop blog post describes when to use setImmediate vs process.nextTick. Although it recommends setImmediate for most cases, in this case, process.nextTick feels more appropriate.
https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#process-nexttick-vs-setimmediate

The relative performance of process.nextTick, setImmediate and setTimeout can be dependent on the hardware, OS, nodeJS version according to this benchmark post. In our testing with NodeJS 8.11.3 on AWS Linux, nextTick was noticeably faster than setImmediate and orders of magnitude faster than setTimeout.

https://gist.github.com/mmalecki/1257394