### PR TITLE
Add in memory dev data store as a configuration option. This allows u…

### DIFF
--- a/configuration.js
+++ b/configuration.js
@@ -1,5 +1,3 @@
-import InMemoryDataSource from "./in_memory_data_source";
-
 const winston = require('winston');
 const InMemoryFeatureStore = require('./feature_store');
 const messages = require('./messages');

--- a/configuration.js
+++ b/configuration.js
@@ -1,3 +1,5 @@
+import InMemoryDataSource from "./in_memory_data_source";
+
 const winston = require('winston');
 const InMemoryFeatureStore = require('./feature_store');
 const messages = require('./messages');
@@ -21,7 +23,8 @@ module.exports = (function() {
       privateAttributeNames: [],
       userKeysCapacity: 1000,
       userKeysFlushInterval: 300,
-      featureStore: InMemoryFeatureStore()
+      featureStore: InMemoryFeatureStore(),
+      inMemoryDevFlags: false,
     };
   };
 
@@ -132,7 +135,7 @@ module.exports = (function() {
 
   function validate(options) {
     let config = Object.assign({}, options || {});
-    
+
     config.userAgent = 'NodeJSClient/' + package_json.version;
     config.logger = (config.logger ||
       new winston.Logger({
@@ -146,7 +149,7 @@ module.exports = (function() {
         ]
       })
     );
-    
+
     checkDeprecatedOptions(config);
 
     const defaultConfig = defaults();

--- a/in_memory_data_source.js
+++ b/in_memory_data_source.js
@@ -1,0 +1,43 @@
+/*
+  DevDataSource provides a way to pass features in to dev without connecting to LaunchDarkly's live service.
+  This would typically be used in a local development environment.
+*/
+
+export default function InMemoryDataSource(features) {
+  if (!features) {
+    return;
+  }
+
+  const flags = {};
+  Object.keys(features).forEach(key => {
+    flags[key] = {
+      key,
+      on: features[key],
+    };
+  });
+  const ld_features = {
+    flags,
+    segments: {},
+  };
+
+  return (config) => {
+    let inited = false;
+    const featureStore = config.featureStore;
+
+    const dev_ds = {
+      start: fn => {
+        featureStore.init(ld_features, () => {
+          inited = true;
+        });
+        const cb = fn || (() => {});
+        cb();
+      },
+      stop: () => {},
+      initialized: () => inited,
+      close: () => {
+        dev_ds.stop();
+      },
+    };
+    return dev_ds;
+  };
+}

--- a/in_memory_data_source.js
+++ b/in_memory_data_source.js
@@ -3,7 +3,7 @@
   This would typically be used in a local development environment.
 */
 
-export default function InMemoryDataSource(features) {
+function InMemoryDataSource(features) {
   if (!features) {
     return;
   }
@@ -41,3 +41,5 @@ export default function InMemoryDataSource(features) {
     return dev_ds;
   };
 }
+
+module.exports = InMemoryDataSource;

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ const newClient = function(sdkKey, originalConfig) {
   const createDefaultUpdateProcessor = config => {
     if (config.inMemoryDevFlags) {
       config.logger.info('Creating in-memory flags for offline usage');
-      return InMemoryDataSource(config.inMemoryDevFlags)
+      return InMemoryDataSource(config.inMemoryDevFlags);
     }
     if (config.useLdd || config.offline) {
       return NullUpdateProcessor();


### PR DESCRIPTION
…sers to pass in small features for evaluation locally without having to connect to Launch Darkly services. This also allows easy "pull and play" configurations

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

This allows a configuration option for feature flags to be evaluated offline in the update processor.

**Describe alternatives you've considered**

In-theory, you could select offline mode and provide an SDK key and file to evaluate, but this gets messy across large distributed teams. This allows us to have one LaunchDarkly config that can be easily changed across branches.

**Additional context**

For our release cycles, it became hard to manage multiple flags, files, and configs. This unifies configuration into the LD configuration and allows new members to pull projects and easily implement local feature flags server-side.