### PR TITLE
Fix/throw err on malformed logger

### DIFF
--- a/configuration.js
+++ b/configuration.js
@@ -147,20 +147,34 @@ module.exports = (function() {
     }
   }
 
+  function validateLogger(logger) {
+    ['error', 'warn', 'info', 'debug'].forEach(function (level) {
+      if (!logger[level] || typeof logger[level] !== 'function') {
+        throw new Error('Provided logger instance must support logger.' + level + '(...)');
+      }
+    })
+  }
+
+  function defaultLogger() {
+    return new winston.Logger({
+      level: 'info',
+      transports: [
+        new winston.transports.Console({
+          formatter: function (options) {
+            return '[LaunchDarkly] ' + (options.message ? options.message : '');
+          },
+        }),
+      ],
+    });
+  }
+
   function validate(options) {
     let config = Object.assign({}, options || {});
-    config.logger =
-      config.logger ||
-      new winston.Logger({
-        level: 'info',
-        transports: [
-          new winston.transports.Console({
-            formatter: function(options) {
-              return '[LaunchDarkly] ' + (options.message ? options.message : '');
-            },
-          }),
-        ],
-      });
+    if (config.logger) {
+      validateLogger(config.logger);
+    } else {
+      config.logger = defaultLogger();
+    }
 
     checkDeprecatedOptions(config);
 

--- a/configuration.js
+++ b/configuration.js
@@ -150,7 +150,7 @@ module.exports = (function() {
   function validateLogger(logger) {
     ['error', 'warn', 'info', 'debug'].forEach(function (level) {
       if (!logger[level] || typeof logger[level] !== 'function') {
-        throw new Error('Provided logger instance must support logger.' + level + '(...)');
+        throw new Error('Provided logger instance must support logger.' + level + '(...) method');
       }
     })
   }

--- a/logger_wrapper.js
+++ b/logger_wrapper.js
@@ -1,0 +1,39 @@
+const logLevels = ['error', 'warn', 'info', 'debug'];
+
+/**
+ * Asserts that the caller-supplied logger contains all required methods
+ * and wraps it in an exception handler that falls back to the fallbackLogger
+ * @param {LDLogger} logger
+ * @param {LDLogger} fallbackLogger
+ */
+function LoggerWrapper(logger, fallbackLogger) {
+  validateLogger(logger);
+
+  const wrappedLogger = {};
+  logLevels.forEach(level => {
+    wrappedLogger[level] = wrapLoggerLevel(logger, fallbackLogger, level);
+  });
+
+  return wrappedLogger;
+}
+
+function validateLogger(logger) {
+  logLevels.forEach(level => {
+    if (!logger[level] || typeof logger[level] !== 'function') {
+      throw new Error('Provided logger instance must support logger.' + level + '(...) method');
+    }
+  });
+}
+
+function wrapLoggerLevel(logger, fallbackLogger, level) {
+  return function wrappedLoggerMethod() {
+    try {
+      return logger[level].apply(logger, arguments);
+    } catch (err) {
+      fallbackLogger.error('Error calling provided logger instance method ' + level + ': ' + err);
+      fallbackLogger[level].apply(fallbackLogger, arguments);
+    }
+  };
+}
+
+module.exports = LoggerWrapper;

--- a/test/configuration-test.js
+++ b/test/configuration-test.js
@@ -22,12 +22,12 @@ describe('configuration', function() {
 
   function checkDeprecated(oldName, newName, value) {
     it('allows "' + oldName + '" as a deprecated equivalent to "' + newName + '"', function() {
-      var config0 = emptyConfigWithMockLogger();
-      config0[oldName] = value;
-      var config1 = configuration.validate(config0);
+      const configIn = emptyConfigWithMockLogger();
+      configIn[oldName] = value;
+      const config1 = configuration.validate(configIn);
       expect(config1[newName]).toEqual(value);
       expect(config1[oldName]).toBeUndefined();
-      expect(config1.logger.warn).toHaveBeenCalledTimes(1);
+      expect(configIn.logger.warn).toHaveBeenCalledTimes(1);
     });
   }
 

--- a/test/configuration-test.js
+++ b/test/configuration-test.js
@@ -2,9 +2,15 @@ var configuration = require('../configuration');
 
 describe('configuration', function() {
   const defaults = configuration.defaults();
-  
+
   function emptyConfigWithMockLogger() {
-    return { logger: { warn: jest.fn() } };
+    const logger = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+    return { logger };
   }
 
   function expectDefault(name) {
@@ -16,17 +22,12 @@ describe('configuration', function() {
 
   function checkDeprecated(oldName, newName, value) {
     it('allows "' + oldName + '" as a deprecated equivalent to "' + newName + '"', function() {
-      var logger = {
-        warn: jest.fn()
-      };
-      var config0 = {
-        logger: logger
-      };
+      var config0 = emptyConfigWithMockLogger();
       config0[oldName] = value;
       var config1 = configuration.validate(config0);
       expect(config1[newName]).toEqual(value);
       expect(config1[oldName]).toBeUndefined();
-      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(config1.logger.warn).toHaveBeenCalledTimes(1);
     });
   }
 
@@ -106,7 +107,7 @@ describe('configuration', function() {
   checkNumericProperty('userKeysCapacity', 500);
   checkNumericProperty('userKeysFlushInterval', 45);
   checkNumericProperty('diagnosticRecordingInterval', 110);
-  
+
   function checkNumericRange(name, minimum, maximum) {
     if (minimum !== undefined) {
       it('enforces minimum for "' + name + '"', () => {

--- a/test/configuration-test.js
+++ b/test/configuration-test.js
@@ -183,4 +183,14 @@ describe('configuration', function() {
     configuration.validate(configIn);
     expect(configIn.logger.warn).toHaveBeenCalledTimes(1);
   });
+
+  it('throws an error if you pass in a logger with missing methods', () => {
+    const methods = ['error', 'warn', 'info', 'debug'];
+
+    methods.forEach(method => {
+      const configIn = emptyConfigWithMockLogger();
+      delete configIn.logger[method];
+      expect(() => configuration.validate(configIn)).toThrow(/Provided logger instance must support .* method/);
+    });
+  });
 });

--- a/test/logger_wrapper-test.js
+++ b/test/logger_wrapper-test.js
@@ -1,0 +1,53 @@
+const LoggerWrapper = require('../logger_wrapper');
+
+describe('LoggerWrapper', function () {
+
+  function mockLogger() {
+    return {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+  }
+
+  const levels = ['error', 'warn', 'info', 'debug'];
+
+  it('throws an error if you pass in a logger that does not conform to the LDLogger schema', () => {
+    const fallbackLogger = mockLogger();
+
+    // If the method does not exist
+    levels.forEach(method => {
+      const logger = mockLogger();
+      delete logger[method];
+      expect(() => LoggerWrapper(logger, fallbackLogger)).toThrow(/Provided logger instance must support .* method/);
+    });
+
+    // If the method is not a function
+    levels.forEach(method => {
+      const logger = mockLogger();
+      logger[method] = 'invalid';
+      expect(() => LoggerWrapper(logger, fallbackLogger)).toThrow(/Provided logger instance must support .* method/);
+    });
+  });
+
+  it('If a logger method throws an error, the error is caught and logged, then the fallback logger is called', () => {
+    const err = Error('Something bad happened');
+
+    levels.forEach(level => {
+      const logger = mockLogger();
+      logger[level] = jest.fn(() => {
+        throw err
+      });
+      const fallbackLogger = mockLogger();
+      const wrappedLogger = LoggerWrapper(logger, fallbackLogger);
+
+      expect(() => wrappedLogger[level]('this is a logline', 'with multiple', 'arguments')).not.toThrow();
+
+      expect(fallbackLogger.error).toHaveBeenNthCalledWith(1, 'Error calling provided logger instance method ' + level + ': ' + err);
+
+      const nthCall = level === 'error' ? 2 : 1;
+      expect(fallbackLogger[level]).toHaveBeenNthCalledWith(nthCall, 'this is a logline', 'with multiple', 'arguments');
+    });
+  });
+});


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

During LaunchDarkly's [April 21](https://status.launchdarkly.com/incidents/g2jjqd9y9pnz) incident, our sdk (5.10.3) reached the following code:

https://github.com/launchdarkly/node-server-sdk/blob/f95665c68c37bc81d47274526ba4abac8ed0bcbe/streaming.js#L33-L34

This was the first time something in the ld library had called `logger.warn`.

Our logger calls this method `logger.warning`

The result:

```
/home/[OMITTED]/node_modules/launchdarkly-node-server-sdk/streaming.js:34
        config.logger.warn(message);
                      ^
TypeError: config.logger.warn is not a function
    at EventSource.es.onerror (/home/[OMITTED]/node_modules/launchdarkly-node-server-sdk/streaming.js:34:23)
    at EventSource.emit (events.js:321:20)
    at EventSource.EventEmitter.emit (domain.js:482:12)
    at _emit (/home/[OMITTED]/node_modules/launchdarkly-node-server-sdk/eventsource.js:194:17)
    at IncomingMessage.onConnectionClosed (/home/[OMITTED]/node_modules/launchdarkly-node-server-sdk/eventsource.js:44:5)
    at IncomingMessage.emit (events.js:333:22)
    at IncomingMessage.EventEmitter.emit (domain.js:482:12)
    at endReadableNT (_stream_readable.js:1204:12)
    at processTicksAndRejections (internal/process/task_queues.js:84:21)
```

An error being thrown in an EventEmitter's error handler causes the process to exit. Try running:
```javascript
const EventEmitter = require('events');

const myEmitter = new EventEmitter();
myEmitter.on('error', (err) => {
    throw new Error('Yikes');
});
myEmitter.emit('error', new Error('whoops!'));
```

All our services restarting at the same time, across all our environments, was very exciting, but I would really like to not have it happen again. 

**Describe the solution you've provided**

I think it makes sense for `configuration.validate` to throw an error when passed a logger that doesn't support all the log levels LD uses internally. This way, mismatched logging APIs will be caught way earlier, before code makes it into production.

It would also be great to update the docs: https://github.com/launchdarkly/LaunchDarkly-Docs/pull/38
 
**Describe alternatives you've considered**

N/A

**Additional context**

N/A
