### PR TITLE
More explicite type for LDEvaluationReason['kind']

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -151,7 +151,7 @@ declare module 'launchdarkly-node-server-sdk' {
      * - `'ERROR'`: The flag could not be evaluated, e.g. because it does not exist or due
      *   to an unexpected error.
      */
-    kind: string;
+    kind: 'OFF' | 'FALLTHROUGH' | 'TARGET_MATCH' | 'RULE_MATCH' | 'PREREQUISITE_FAILED' | 'ERROR'; 
 
     /**
      * A further description of the error condition, if the kind was `'ERROR'`.


### PR DESCRIPTION
**Requirements**

- [N/A] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [N/A] I have validated my changes against all supported platform versions

**Related issues**
None

**Describe the solution you've provided**
Improved type for the LDEvaluationReason kind property so it reflects the possible enum values. This will help people by allowing typescript to catch...
1. Spelling errors
2. Casing errors
3. Unsupported reason kinds that have been removed.

**Describe alternatives you've considered**
One other alternative was separating out `LDEvaluationReason` into multiple types to address the different possible keys and use a union type to merge them together. However, this would ruin the jsdoc as far as I am aware...

```typescript
  export interface LDEvaluationReasonOff {
    kind: 'OFF'
  }
  export interface LDEvaluationReasonError {
    kind: 'ERROR';
    errorKind: string;
  }
  export interface LDEvaluationReasonRuleMatch {
    kind: 'RULE_MATCH'
    ruleIndex: number;
    ruleId: string;
  }

type LDEvaluationReason = LDEvaluationReasonOff | LDEvaluationReasonError | LDEvaluationReasonRuleMatch 

```

**Additional context**

While string as a type for kind is technically valid, it implies that any possible string is acceptable. However, it appears that the kind property is more of a string enum and has very specific values.