### PR TITLE
Remove combine function from Winston due to error

### DIFF
--- a/configuration.js
+++ b/configuration.js
@@ -159,7 +159,7 @@ module.exports = (function() {
       level: 'info',
       transports: [
         new winston.transports.Console({
-          format: winston.format.combine(prefixFormat(), winston.format.simple()),
+          format: prefixFormat(),
         }),
       ],
     });


### PR DESCRIPTION
Remove winston.format.combine from SDK due to MODULE_NOT_FOUND on lambda.
Using parcel.

`{
    "errorType": "Error",
    "errorMessage": "Cannot find module './combine.js'\nRequire stack:\n- /var/task/index.js\n- /var/runtime/UserFunction.js\n- /var/runtime/index.js",
    "code": "MODULE_NOT_FOUND",
    "requireStack": [
        "/var/task/index.js",
        "/var/runtime/UserFunction.js",
        "/var/runtime/index.js"
    ],
    "stack": [
        "Error: Cannot find module './combine.js'",
        "Require stack:",
        "- /var/task/index.js",
        "- /var/runtime/UserFunction.js",
        "- /var/runtime/index.js",
        "    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:966:15)",
        "    at Function.Module._load (internal/modules/cjs/loader.js:842:27)",
        "    at Module.require (internal/modules/cjs/loader.js:1026:19)",
        "    at require (internal/modules/cjs/helpers.js:72:18)",
        "    at f (/var/task/index.js:1:293)",
        "    at f (/var/task/index.js:1:233)",
        "    at p (/var/task/index.js:1:544)",
        "    at Function.get (/var/task/index.js:920:115)",
        "    at u (/var/task/index.js:1358:1584)",
        "    at Object.validate (/var/task/index.js:1358:1712)"
    ]
}`