### PR TITLE
Change some for ... in .. clauses to for ... of ...

### DIFF
--- a/feature_store_event_wrapper.js
+++ b/feature_store_event_wrapper.js
@@ -32,8 +32,7 @@ function NamespacedDataSet() {
     for (const ns in itemsByNamespace) {
       const items = itemsByNamespace[ns];
       const keys = Object.keys(items).sort(); // sort to make tests determinate
-      for (const i in keys) {
-        const key = keys[i];
+      for (const key of keys) {
         callback(ns, key, items[key]);
       }
     }
@@ -138,16 +137,14 @@ function FeatureStoreEventWrapper(featureStore, emitter) {
   function computeDependencies(kind, item) {
     const ret = NamespacedDataSet();
     if (kind === dataKind.features) {
-      for (const i in item.prerequisites || []) {
-        ret.set(dataKind.features.namespace, item.prerequisites[i].key, true);
+      for (const prerequisite of item.prerequisites || []) {
+        ret.set(dataKind.features.namespace, prerequisite.key, true);
       }
-      for (const i in item.rules || []) {
-        const rule = item.rules[i];
-        for (const j in rule.clauses || []) {
-          const clause = rule.clauses[j];
+      for (const rule of item.rules || []) {
+        for (const clause of rule.clauses || []) {
           if (clause.op === 'segmentMatch') {
-            for (const k in clause.values) {
-              ret.set(dataKind.segments.namespace, clause.values[k], true);
+            for (const value of clause.values) {
+              ret.set(dataKind.segments.namespace, value, true);
             }
           }
         }


### PR DESCRIPTION
Context: I am running a nodejs server that I was trying to integrate this library into.

However, our server uses some monkeypatched extensions of Arrays for convenience. Functions like `first`, `last`, `pluck`, etc (`Array.prototype.first = function() {...}`)

When trying to integrate this library into my project, it failed on the call to `init`, because this code was iterating not only over the indices in the arrays (0, 1, 2, etc), but also the names of our extension (first, last, pluck, etc).

This obviously threw an error when it tried to call `clause.op` on a Function.

I'm sure there's opinions out there either way on the practice of monkeypatching a global object type like Array, but regardless this made it much harder to integrate launchdarkly because I had to go through and remove all our extensions from the code.

As far as I know, `for ... of ...` is the recommended method to iterate over arrays as well.

I've gone ahead and changed all the instances of `for ... in ...` that were preventing library initialization. There may be more `for ... in ...` that should be converted to `for ... of ...`, but I suppose half the purpose of this PR is to draw your attention to this issue and get a conversation going.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
