### PR TITLE
Fix TestData.ifMatch rule matching

### DIFF
--- a/test/test_data-test.js
+++ b/test/test_data-test.js
@@ -222,7 +222,7 @@ describe('TestData', function() {
           {
             "attribute": "name",
             "negate": false,
-            "operator": "in",
+            "op": "in",
             "values":  [
               "ben",
               "christian",
@@ -231,7 +231,46 @@ describe('TestData', function() {
           {
             "attribute": "country",
             "negate": true,
-            "operator": "in",
+            "op": "in",
+            "values":  [
+              "fr",
+            ],
+          },
+        ],
+      }
+    ]);
+
+    const clearedRulesFlag = flag.clearRules();
+    expect(clearedRulesFlag.build(0)).not.toHaveProperty('rules');
+  });
+
+  it('can update after adding a rule', function() {
+    const td = TestData();
+    const flag = td.update(
+      td.flag('test-flag')
+        .ifMatch('name', 'ben', 'christian')
+        .andNotMatch('country', 'fr')
+        .thenReturn(true)
+      );
+
+    expect(flag.build().rules).toEqual([
+      {
+        "id": "rule0",
+        "variation": 0,
+        "clauses":  [
+          {
+            "attribute": "name",
+            "negate": false,
+            "op": "in",
+            "values":  [
+              "ben",
+              "christian",
+            ],
+          },
+          {
+            "attribute": "country",
+            "negate": true,
+            "op": "in",
             "values":  [
               "fr",
             ],

--- a/test/test_data-test.js
+++ b/test/test_data-test.js
@@ -246,40 +246,11 @@ describe('TestData', function() {
 
   it('can update after adding a rule', function() {
     const td = TestData();
-    const flag = td.update(
-      td.flag('test-flag')
-        .ifMatch('name', 'ben', 'christian')
-        .andNotMatch('country', 'fr')
-        .thenReturn(true)
-      );
+    const flag = td.flag('test-flag')
+                   .ifMatch('name', 'ben', 'christian')
+                   .andNotMatch('country', 'fr')
+                   .thenReturn(true);
 
-    expect(flag.build().rules).toEqual([
-      {
-        "id": "rule0",
-        "variation": 0,
-        "clauses":  [
-          {
-            "attribute": "name",
-            "negate": false,
-            "op": "in",
-            "values":  [
-              "ben",
-              "christian",
-            ],
-          },
-          {
-            "attribute": "country",
-            "negate": true,
-            "op": "in",
-            "values":  [
-              "fr",
-            ],
-          },
-        ],
-      }
-    ]);
-
-    const clearedRulesFlag = flag.clearRules();
-    expect(clearedRulesFlag.build(0)).not.toHaveProperty('rules');
+    expect(() => td.update(flag)).not.toThrow()
   });
 });

--- a/test_data.js
+++ b/test_data.js
@@ -97,7 +97,7 @@ TestDataFlagBuilder.prototype.copy = function () {
   to._on = this._on;
   to._fallthroughVariation = this._fallthroughVariation;
   to._targets = !this._targets ? null : new Map(this._targets);
-  to._rules = !this.rules ? null : this._rules.map(rule => rule.copy())
+  to._rules = !this.rules ? null : this._rules.map(rule => rule.copy());
   return to;
 };
 
@@ -297,7 +297,7 @@ TestDataRuleBuilder.prototype.build = function (id) {
 
 TestDataRuleBuilder.prototype.copy = function () {
   const flagRuleBuilder = new TestDataRuleBuilder(this);
-  flagRuleBuilder._clauses = JSON.parse(JSON.stringify(this._clauses))
+  flagRuleBuilder._clauses = JSON.parse(JSON.stringify(this._clauses));
   flagRuleBuilder._variation = this._variation;
   return flagRuleBuilder;
 };

--- a/test_data.js
+++ b/test_data.js
@@ -302,5 +302,4 @@ TestDataRuleBuilder.prototype.copy = function () {
   return flagRuleBuilder;
 };
 
-
 module.exports = TestData;

--- a/test_data.js
+++ b/test_data.js
@@ -97,7 +97,7 @@ TestDataFlagBuilder.prototype.copy = function () {
   to._on = this._on;
   to._fallthroughVariation = this._fallthroughVariation;
   to._targets = !this._targets ? null : new Map(this._targets);
-  to._rules = !this._rules ? null : JSON.parse(JSON.stringify(this._rules));
+  to._rules = !this.rules ? null : this._rules.map(rule => rule.copy())
   return to;
 };
 
@@ -259,7 +259,7 @@ function TestDataRuleBuilder(flagBuilder) {
 TestDataRuleBuilder.prototype.andMatch = function (attribute, ...values) {
   this._clauses.push({
     attribute: attribute,
-    operator: 'in',
+    op: 'in',
     values: values,
     negate: false,
   });
@@ -269,7 +269,7 @@ TestDataRuleBuilder.prototype.andMatch = function (attribute, ...values) {
 TestDataRuleBuilder.prototype.andNotMatch = function (attribute, ...values) {
   this._clauses.push({
     attribute: attribute,
-    operator: 'in',
+    op: 'in',
     values: values,
     negate: true,
   });
@@ -294,5 +294,13 @@ TestDataRuleBuilder.prototype.build = function (id) {
     clauses: this._clauses,
   };
 };
+
+TestDataRuleBuilder.prototype.copy = function () {
+  const flagRuleBuilder = new TestDataRuleBuilder(this);
+  flagRuleBuilder._clauses = JSON.parse(JSON.stringify(this._clauses))
+  flagRuleBuilder._variation = this._variation;
+  return flagRuleBuilder;
+};
+
 
 module.exports = TestData;


### PR DESCRIPTION
The rule was not matching, after debugging it was found that the expected rule operator field was named `op` not `operator`. This was found by debugging until getting to the matchFn function in `evaluator.js`.

There was also another issue where updating when using an ifMatch resulted in a JSON ref error.  Replaced JSON based copy with manual copy. 
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**
https://github.com/launchdarkly/node-server-sdk/issues/258

**Describe the solution you've provided**
This PR fixes the JSON circular ref by using a manual copy method in TestDataRuleBuilder rather than using JSON.stringify.
It fixes the rules not matching by using `op` rather than `operator` when using `TestDataRuleBuilder.andMatch`

